### PR TITLE
build: upgrade Playwright and synchronize browser versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      playwright:
+        patterns:
+          - playwright
+          - "@playwright/test"
     labels: [dependencies]
 
   - package-ecosystem: github-actions

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,5 +1,6 @@
+ARG PLAYWRIGHT_VERSION
 FROM node:26.7.0-bookworm-slim AS node
-FROM mcr.microsoft.com/playwright:v1.62.1-noble
+FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential python3 \

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -53,9 +53,10 @@ repository's required checks if merges must be blocked on visual regressions.
 already inside the canonical environment. Normal runs never create or update
 baselines, and updating images never bypasses behavioral assertions.
 
-The Playwright package and browser image versions are pinned together. When
-upgrading Playwright, update both dependencies and `e2e/Dockerfile`, regenerate
-baselines in the updated image, and review the rendering differences.
+Both Playwright dependencies must use the same exact version. Dependabot groups
+them in one update, and the Docker runner derives the browser image version from
+that pin. When upgrading, run the tests in the updated image and review any
+rendering differences before updating affected baselines.
 
 ## Coverage and deterministic inputs
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "zod": "^4.5.4"
   },
   "devDependencies": {
-    "@playwright/test": "1.62.1",
+    "@playwright/test": "1.63.0",
     "@tailwindcss/vite": "^4.3.3",
     "@types/better-sqlite3": "^9.6.0",
     "@types/dockerode": "^4.0.1",
@@ -94,7 +94,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-simple-import-sort": "^14.0.0",
-    "playwright": "1.62.1",
+    "playwright": "1.63.0",
     "prettier": "^3.9.6",
     "supertest": "^7.2.2",
     "tailwindcss": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         version: 4.5.4
     devDependencies:
       '@playwright/test':
-        specifier: 1.62.1
-        version: 1.62.1
+        specifier: 1.63.0
+        version: 1.63.0
       '@tailwindcss/vite':
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.13)(yaml@2.9.0))
@@ -184,8 +184,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0(eslint@10.10.0(jiti@2.7.0)(supports-color@10.2.2))
       playwright:
-        specifier: 1.62.1
-        version: 1.62.1
+        specifier: 1.63.0
+        version: 1.63.0
       prettier:
         specifier: ^3.9.6
         version: 3.9.6
@@ -885,8 +885,8 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.62.1':
-    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+  '@playwright/test@1.63.0':
+    resolution: {integrity: sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -2579,11 +2579,6 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3471,13 +3466,13 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.62.1:
-    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+  playwright-core@1.63.0:
+    resolution: {integrity: sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==}
     engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.62.1:
-    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+  playwright@1.63.0:
+    resolution: {integrity: sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -4795,9 +4790,9 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@playwright/test@1.62.1':
+  '@playwright/test@1.63.0':
     dependencies:
-      playwright: 1.62.1
+      playwright: 1.63.0
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -6570,9 +6565,6 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fsevents@2.3.2:
-    optional: true
-
   fsevents@2.3.3:
     optional: true
 
@@ -7577,13 +7569,11 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  playwright-core@1.62.1: {}
+  playwright-core@1.63.0: {}
 
-  playwright@1.62.1:
+  playwright@1.63.0:
     dependencies:
-      playwright-core: 1.62.1
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright-core: 1.63.0
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scripts/e2e-docker.sh
+++ b/scripts/e2e-docker.sh
@@ -2,7 +2,15 @@
 # Canonical environment for both CI and reviewed baseline updates.
 set -eu
 cd "$(dirname "$0")/.."
-docker build -f e2e/Dockerfile -t dockdash-e2e .
+PLAYWRIGHT_VERSION=$(node --input-type=commonjs -e '
+  const { devDependencies } = require("./package.json");
+  const version = devDependencies["@playwright/test"];
+  if (!/^\d+\.\d+\.\d+$/.test(version) || version !== devDependencies.playwright) {
+    throw new Error("Pin playwright and @playwright/test to the same exact version");
+  }
+  process.stdout.write(version);
+')
+docker build --build-arg "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" -f e2e/Dockerfile -t dockdash-e2e .
 docker run --rm --ipc=host \
   -v "$PWD:/work" \
   -v /work/node_modules \


### PR DESCRIPTION
Separate Playwright updates load mismatched test-runner versions and fail before the UI suite can run. Upgrade `playwright` and `@playwright/test` together to 1.63.0 and derive the Docker browser image version from their shared exact pin, rejecting mismatched versions before building.

Group both npm packages in Dependabot so future upgrades arrive together. Supersedes #79 and #80.

Validation: lint, application and E2E typechecks, 561 unit tests, and all 20 desktop E2E tests in the Playwright 1.63.0 Docker image. Existing screenshot baselines pass unchanged.
